### PR TITLE
Fix timezone issue in date calculation causing incorrect overdue display

### DIFF
--- a/frontend/lib/utils-date.ts
+++ b/frontend/lib/utils-date.ts
@@ -1,7 +1,17 @@
 export function isToday(dateString: string | null): boolean {
   if (!dateString) return false
 
-  const date = new Date(dateString)
+  // Parse date and convert to local date to avoid timezone issues
+  let date: Date
+  if (dateString.includes('T')) {
+    // If it's a full ISO string, extract just the date part
+    const datePart = dateString.split('T')[0]
+    date = new Date(datePart + 'T00:00:00')
+  } else {
+    // If it's just a date string, parse as local date
+    date = new Date(dateString + 'T00:00:00')
+  }
+  
   const today = new Date()
 
   // Check if date is valid
@@ -13,7 +23,16 @@ export function isToday(dateString: string | null): boolean {
 export function daysUntil(dateString: string | null): number {
   if (!dateString) return Number.POSITIVE_INFINITY
 
-  const date = new Date(dateString)
+  // Parse date and convert to local date to avoid timezone issues
+  let date: Date
+  if (dateString.includes('T')) {
+    // If it's a full ISO string, extract just the date part
+    const datePart = dateString.split('T')[0]
+    date = new Date(datePart + 'T00:00:00')
+  } else {
+    // If it's just a date string, parse as local date
+    date = new Date(dateString + 'T00:00:00')
+  }
   
   // Check if date is valid
   if (isNaN(date.getTime())) return Number.POSITIVE_INFINITY
@@ -29,7 +48,16 @@ export function daysUntil(dateString: string | null): number {
 export function formatDueDate(dateString: string | null): string {
   if (!dateString) return "No due"
 
-  const date = new Date(dateString)
+  // Parse date and convert to local date to avoid timezone issues
+  let date: Date
+  if (dateString.includes('T')) {
+    // If it's a full ISO string, extract just the date part
+    const datePart = dateString.split('T')[0]
+    date = new Date(datePart + 'T00:00:00')
+  } else {
+    // If it's just a date string, parse as local date
+    date = new Date(dateString + 'T00:00:00')
+  }
   
   // Check if date is valid
   if (isNaN(date.getTime())) return "Invalid date"


### PR DESCRIPTION
## Problem
Tasks with due dates like '2025-09-06T00:00:00.000Z' were incorrectly showing as '1 days overdue' when they should show as 'Today'. This was caused by timezone conversion issues where UTC dates were being interpreted as the previous day in local timezone.

## Root Cause
- UTC date strings (e.g., '2025-09-06T00:00:00.000Z') were being parsed directly by new Date()
- In CDT timezone (UTC-5), this resulted in the date being interpreted as the previous day at 19:00
- When setHours(0,0,0,0) was applied, it became the previous day at 00:00
- This caused daysUntil() to return -1 instead of 0 for today's tasks

## Solution
- Modified isToday(), daysUntil(), and formatDueDate() functions to handle timezone issues
- For ISO date strings with 'T', extract only the date part (YYYY-MM-DD) and append 'T00:00:00'
- This ensures the date is parsed as local time instead of UTC time
- Maintains backward compatibility with simple date strings

## Technical Changes
- Enhanced date parsing logic to distinguish between ISO strings and simple date strings
- Added proper timezone handling to prevent UTC-to-local conversion issues
- Preserved existing functionality for non-ISO date formats

## Result
- Tasks due today now correctly display as 'Today' instead of '1 days overdue'
- Date calculations are now timezone-aware and accurate
- All existing date functionality remains intact